### PR TITLE
Fix: use node20 runtime (node22 is not valid)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ outputs:
   changes:
     description: Total number of changes
 runs:
-  using: node22
+  using: node20
   main: action/index.js


### PR DESCRIPTION
## Summary
- `node22` is not a valid GitHub Actions runtime — only `node12`, `node16`, `node20`, and `node24` are supported
- Reverts runtime to `node20`, which is the correct choice since the navigator fix from PR #2 makes the bundle compatible when GitHub force-upgrades to node24

## Error from CI
```
'using: node22' is not supported, use 'docker', 'node12', 'node16', 'node20' or 'node24' instead.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)