### PR TITLE
Update action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ outputs:
   changes:
     description: Total number of changes
 runs:
-  using: node20
+  using: node24
   main: action/index.js


### PR DESCRIPTION
## Summary
- Updates runtime from `node20` to `node24` (the latest supported GitHub Actions runtime)
- Eliminates deprecation warnings and force-upgrade behavior
- Bundle already verified working on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)